### PR TITLE
Reuse constructor passed OkHttpClient instance

### DIFF
--- a/src/main/java/svarzee/gps/gpsoauth/Gpsoauth.java
+++ b/src/main/java/svarzee/gps/gpsoauth/Gpsoauth.java
@@ -130,8 +130,6 @@ public class Gpsoauth {
                                String operatorCountry,
                                String lang,
                                String sdkVersion) throws IOException {
-    OkHttpClient httpClient = new OkHttpClient();
-
     FormBody formBody = new FormBody.Builder()
         .add("accountType", "HOSTED_OR_GOOGLE")
         .add("Email", username)


### PR DESCRIPTION
It's better to use OkHttpClient instance from the constuctor for example to specify a proxy.